### PR TITLE
Strip argv[0] leading path in openlog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-03-08 Sevag Hanssian <sevag.hanssian@gmail.com>
+
+	* ipmiseld/ipmiseld.c,
+	ipmidetectd/ipmidetectd.c,
+	bmc-watchdog/bmc-watchdog.c: Strip path from argv[0] in syslog
+
 2018-02-20 Jo Fahlke <jorrit@jorrit.de>
 
 	* ipmi-config/: Simplify legacy command scripts to not mangle

--- a/bmc-watchdog/bmc-watchdog.c
+++ b/bmc-watchdog/bmc-watchdog.c
@@ -1431,8 +1431,11 @@ main (int argc, char **argv)
     _stop_cmd ();
   else if (cmd_args.clear)
     _clear_cmd ();
-  else if (cmd_args.daemon)
+  else if (cmd_args.daemon) {
+    if (argv[0][0] == '/')
+      argv[0] = strrchr(argv[0], '/') + 1;
     _daemon_cmd (argv[0]);
+  }
   else
     err_exit ("internal error, command not set");
 

--- a/ipmidetectd/ipmidetectd.c
+++ b/ipmidetectd/ipmidetectd.c
@@ -723,6 +723,8 @@ main (int argc, char **argv)
   /* Call after daemonization, since daemonization closes currently
    * open fds
    */
+  if (argv[0][0] == '/')
+    argv[0] = strrchr(argv[0], '/') + 1;
   openlog (argv[0], LOG_ODELAY | LOG_PID, LOG_DAEMON);
 
   _ipmidetectd_loop ();

--- a/ipmiseld/ipmiseld.c
+++ b/ipmiseld/ipmiseld.c
@@ -1798,6 +1798,8 @@ main (int argc, char **argv)
       /* Call after daemonization, since daemonization closes currently
        * open fds
        */
+      if (argv[0][0] == '/')
+        argv[0] = strrchr(argv[0], '/') + 1;
       openlog (argv[0], LOG_ODELAY | LOG_PID, prog_data.log_facility);
     }
 


### PR DESCRIPTION
Follow-up PR to this issue: https://github.com/chu11/freeipmi-mirror/issues/22

Stripping the leading path portions of argv[0] seems to be the most popular of presenting a good daemon name.