### PR TITLE
libfreeipmi/ipmi-sensor-read.c: Incorrect sensor reading reported

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-05-29 Heather Lemon <heather.lemon@canonical.com>
+
+	* libfreeipmi/sensor-read/ipmi-sensor-read.c: (LP#1926299)
+	Incorrect sensor reading reported.
+	BMC's that use a non-zero 'LUN' number (00b-10b)
+	will display an incorrect sensor temperature reading unless
+	otherwise specified via the ipmiV2.0 spec and must be accessed via LUN 00b.
+
 2021-03-27 Albert Chu <chu11@llnl.gov>
 
 	* etc: Generate many files via configure to ensure proper paths

--- a/libfreeipmi/sensor-read/ipmi-sensor-read.c
+++ b/libfreeipmi/sensor-read/ipmi-sensor-read.c
@@ -40,6 +40,7 @@
 #include "freeipmi/record-format/ipmi-sdr-record-format.h"
 #include "freeipmi/spec/ipmi-channel-spec.h"
 #include "freeipmi/spec/ipmi-comp-code-spec.h"
+#include "freeipmi/spec/ipmi-ipmb-lun-spec.h"
 #include "freeipmi/spec/ipmi-slave-address-spec.h"
 #include "freeipmi/spec/ipmi-sensor-units-spec.h"
 #include "freeipmi/util/ipmi-sensor-and-event-code-tables-util.h"
@@ -569,7 +570,7 @@ ipmi_sensor_read (ipmi_sensor_read_ctx_t ctx,
    */
   if (!(ctx->flags & IPMI_SENSOR_READ_FLAGS_ASSUME_BMC_OWNER))
     {
-      if (slave_address == IPMI_SLAVE_ADDRESS_BMC)
+      if (slave_address == IPMI_SLAVE_ADDRESS_BMC && sensor_owner_lun == IPMI_BMC_IPMB_LUN_BMC)
         {
           if (_get_sensor_reading (ctx,
                                    sensor_number,


### PR DESCRIPTION
Incorrect sensor reading reported with ipmi-sensor

Fixes: #42 