### PR TITLE
Warning about NUL

### DIFF
--- a/etc/freeipmi.conf
+++ b/etc/freeipmi.conf
@@ -521,7 +521,8 @@
 # IPMICONSOLE OPTIONS
 #
 # The following options are specific to ipmiconsole(8).  They will be
-# ignored by other tools.
+# ignored by other tools.  See "man 8 ipmiconsole" for their exact
+# behaviour.
 #
 # ipmiconsole-username myusername
 #

--- a/man/freeipmi.conf.5.pre.in
+++ b/man/freeipmi.conf.5.pre.in
@@ -1150,10 +1150,12 @@ Specify the default escape character.
 Specify if in use SOL sessions should not be stolen by default.
 .TP
 \fBipmiconsole\-serial\-keepalive\fR \fIENABLE|DISABLE\fR
-Specify if serial keepalive should be enabled by default.
+Specify if serial keepalive should be enabled by default.  See "man
+8 ipmiconsole" for details of how this option works.
 .TP
 \fBipmiconsole\-serial\-keepalive\-empty\fR \fIENABLE|DISABLE\fR
-Specify if serial keepalive empty should be enabled by default.
+Specify if serial keepalive empty should be enabled by default.  See
+"man 8 ipmiconsole" for details of how this option works.
 .TP
 \fBipmiconsole\-sol\-payload\-instance\fR \fINUM\fR
 Specify the default SOL payload instance.

--- a/man/ipmiconsole.8.pre.in
+++ b/man/ipmiconsole.8.pre.in
@@ -119,7 +119,12 @@ is only detected once there is user interaction.  By sending the
 occasional NUL character, the underlying loss of serial data transfer
 can be detected far more quickly.  There is some risk with this option,
 as the NUL character byte may affect the remote system depending on
-what data it may or may not be expecting.
+what data it may or may not be expecting.  In particular, getty and
+its descendants on most Unix systems (such as agetty, the normal
+console terminal program on Linux) will cause a baud rate change
+when they receive a NUL, which effectively locks up the terminal
+completely.  See https://github.com/karelzak/util-linux/issues/1371
+for detailed discussion of this issue.
 .TP
 \fB\-\-serial\-keepalive\-empty\fR
 This option is identical to \fB\-\-serial\-keepalive\fR except that

--- a/man/libipmiconsole.conf.5.pre.in
+++ b/man/libipmiconsole.conf.5.pre.in
@@ -119,7 +119,9 @@ header file for additional information on the library.
 \fBlibipmiconsole\-context\-engine\-flags\fR \fIFLAGS\fR
 Specify default engine flags to use.  Multiple flags can be specified
 separated by whitespace.  The following flags are supported: closefd,
-outputonsolestablished, lockmemory, serialkeepalive.
+outputonsolestablished, lockmemory, serialkeepalive,
+serialkeepaliveempty.  See "man 8 ipmiconsole" for details of what
+these options do.
 .TP
 \fBlibipmiconsole\-context\-behavior\-flags\fR \fIFLAGS\fR
 Specify default behavior flags to use.  Multiple flags can be


### PR DESCRIPTION
The issues described herein was the cause of a multi-hour debugging
session after *thousands* of consoles were locked into the wrong baud
rate in a datacenter.

Happy to change the wording, but I feel like some kind of "this is not a
theoretical problem" warning needs to be in there.  :)