### PR TITLE
fix build on musl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -479,6 +479,7 @@ AC_CHECK_FUNCS([flockfile fputs_unlocked fwrite_unlocked])
 AC_CHECK_FUNCS([iopl])
 AC_CHECK_FUNCS([asprintf])
 AC_CHECK_FUNCS([cbrt])
+AC_CHECK_FUNCS([getmsg putmsg])
 
 dnl sighandler_t apparently not defined in Apple/OS X
 AC_CHECK_TYPES([sighandler_t], [], [], [[#include <signal.h>]])

--- a/libfreeipmi/driver/ipmi-sunbmc-driver.c
+++ b/libfreeipmi/driver/ipmi-sunbmc-driver.c
@@ -423,7 +423,7 @@ _sunbmc_write (ipmi_sunbmc_ctx_t ctx,
   assert (ctx->io_init);
   assert (ctx->putmsg_intf);
 
-#if defined(HAVE_SYS_STROPTS_H)
+#if defined(HAVE_SYS_STROPTS_H) && defined(HAVE_PUTMSG)
   memset (&sbuf, '\0', sizeof (struct strbuf));
 
   /* Due to API differences, we need to extract the cmd out of the
@@ -573,7 +573,7 @@ _sunbmc_read (ipmi_sunbmc_ctx_t ctx,
       return (-1);
     }
 
-#if defined(HAVE_SYS_STROPTS_H)
+#if defined(HAVE_SYS_STROPTS_H) && defined(HAVE_GETMSG)
   if (getmsg (ctx->device_fd, NULL, &sbuf, &flags) < 0)
     {
       SUNBMC_ERRNO_TO_SUNBMC_ERRNUM (ctx, errno);


### PR DESCRIPTION
musl doesn't provide getmsg or putmsg even if stropts.h is available

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>