### PR TITLE
configure.ac: use pkg-config to find gcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -405,7 +405,11 @@ fi
 dnl Checks for libraries.
 dnl don\'t include lib if LAN not desired
 if test x"${ac_with_encryption}" = xyes; then
-  AC_CHECK_LIB([gcrypt], [gcry_md_open], [have_gcrypt=yes], [have_gcrypt=no])
+  PKG_CHECK_MODULES([GCRYPT], [libgcrypt], [have_gcrypt=yes], [
+     AC_CHECK_LIB([gcrypt], [gcry_md_open],
+        [have_gcrypt=yes GCRYPT_LIBS=-lgcrypt],
+        [have_gcrypt=no])
+  ])
   if test "x${have_gcrypt}" = "xno"; then
      AC_MSG_ERROR([libgcrypt required to build libfreeipmi])
      AC_MSG_NOTICE([Note: libgpg-error required for libgcrypt])
@@ -421,7 +425,6 @@ if test x"${ac_with_encryption}" = xyes; then
   if test "x${have_gcrypt_threads}" = "xno"; then
      AC_MSG_ERROR([libgcrypt with threads support required for libfreeipmi])
   fi
-  GCRYPT_LIBS=-lgcrypt
 fi
 AC_SUBST(GCRYPT_LIBS)
 


### PR DESCRIPTION
Use pkg-config to find gcrypt and avoid the following static build failure:

```
configure:13642: checking for gcry_md_open in -lgcrypt
configure:13665: /home/buildroot/autobuild/instance-1/output-1/host/bin/x86_64-linux-gcc -o conftest -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os -g0  -static -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -static conftest.c -lgcrypt   >&5
/home/buildroot/autobuild/instance-1/output-1/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-musl/10.3.0/../../../../x86_64-buildroot-linux-musl/bin/ld: /home/buildroot/autobuild/instance-1/output-1/host/x86_64-buildroot-linux-musl/sysroot/usr/lib/../lib64/libgcrypt.a(libgcrypt_la-visibility.o): in function `gcry_err_make_from_errno':
visibility.c:(.text+0x29): undefined reference to `gpg_err_code_from_errno'
```

Fixes:
 - http://autobuild.buildroot.org/results/5354f7231cf08bf762e7d86fca874ce63d9a116b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>