### PR TITLE
ipmi-sel: make --date-range more granular

### DIFF
--- a/ipmi-sel/ipmi-sel-argp.c
+++ b/ipmi-sel/ipmi-sel-argp.c
@@ -96,16 +96,12 @@ static struct argp_option cmdline_options[] =
       "Display SEL records from record id START to END.", 44},
     { "exclude-display-range", EXCLUDE_DISPLAY_RANGE_KEY, "START-END", 0,
       "Exclude display of SEL records from record id START to END.", 45},
-    { "date-range", DATE_RANGE_KEY,
-      "MM/DD/YYYY-MM/DD/YYYY"
-      "\n                   "
-      "YYYY-MM-DDTHH:MM:SS-YYYY-MM-DDTHH:MM:SS", 0,
-      "Display SEL records in the specified date range.", 46},
-    { "exclude-date-range", EXCLUDE_DATE_RANGE_KEY,
-      "MM/DD/YYYY-MM/DD/YYYY"
-      "\n                           "
-      "YYYY-MM-DDTHH:MM:SS-YYYY-MM-DDTHH:MM:SS", 0,
-      "Exclude display of SEL records in the specified date range.", 47},
+    { "date-range", DATE_RANGE_KEY, "DATE1-DATE2", 0,
+      "Display SEL records in the specified date range. "
+      "See manpage for accepted date formats.", 46},
+    { "exclude-date-range", EXCLUDE_DATE_RANGE_KEY, "DATE1-DATE2", 0,
+      "Exclude display of SEL records in the specified date range. "
+      "See manpage for accepted date formats.", 47},
     { "sensor-types",   SENSOR_TYPES_KEY,       "SENSOR-TYPES-LIST", 0,
       "Show sensors of a specific type.", 46},
     { "exclude-sensor-types", EXCLUDE_SENSOR_TYPES_KEY, "SENSOR-TYPES-LIST", 0,

--- a/ipmi-sel/ipmi-sel-argp.c
+++ b/ipmi-sel/ipmi-sel-argp.c
@@ -96,9 +96,15 @@ static struct argp_option cmdline_options[] =
       "Display SEL records from record id START to END.", 44},
     { "exclude-display-range", EXCLUDE_DISPLAY_RANGE_KEY, "START-END", 0,
       "Exclude display of SEL records from record id START to END.", 45},
-    { "date-range", DATE_RANGE_KEY, "MM/DD/YYYY-MM/DD/YYYY", 0,
+    { "date-range", DATE_RANGE_KEY,
+      "MM/DD/YYYY-MM/DD/YYYY"
+      "\n                   "
+      "YYYY-MM-DDTHH:MM:SS-YYYY-MM-DDTHH:MM:SS", 0,
       "Display SEL records in the specified date range.", 46},
-    { "exclude-date-range", EXCLUDE_DATE_RANGE_KEY, "MM/DD/YYYY-MM/DD/YYYY", 0,
+    { "exclude-date-range", EXCLUDE_DATE_RANGE_KEY,
+      "MM/DD/YYYY-MM/DD/YYYY"
+      "\n                           "
+      "YYYY-MM-DDTHH:MM:SS-YYYY-MM-DDTHH:MM:SS", 0,
       "Exclude display of SEL records in the specified date range.", 47},
     { "sensor-types",   SENSOR_TYPES_KEY,       "SENSOR-TYPES-LIST", 0,
       "Show sensors of a specific type.", 46},
@@ -288,6 +294,7 @@ _read_date_range (int *flag,
   unsigned int dash_count = 0;
   time_t t;
   struct tm tm;
+  int range2_is_iso8601 = 1;
 
   assert (flag);
   assert (range1);
@@ -376,18 +383,21 @@ _read_date_range (int *flag,
     t = time (NULL);
   else
     {
-      if (!strptime (range1_str, "%m/%d/%Y", &tm))
+      if (!strptime (range1_str, "%FT%T", &tm))
         {
-          if (!strptime (range1_str, "%b/%d/%Y", &tm))
+          if (!strptime (range1_str, "%m/%d/%Y", &tm))
             {
-              if (!strptime (range1_str, "%m-%d-%Y", &tm))
+              if (!strptime (range1_str, "%b/%d/%Y", &tm))
                 {
-                  if (!strptime (range1_str, "%b-%d-%Y", &tm))
+                  if (!strptime (range1_str, "%m-%d-%Y", &tm))
                     {
-                      fprintf (stderr,
-                               "Invalid time specification '%s'.\n",
-                               range1_str);
-                      exit (EXIT_FAILURE);
+                      if (!strptime (range1_str, "%b-%d-%Y", &tm))
+                        {
+                          fprintf (stderr,
+                                   "Invalid time specification '%s'.\n",
+                                   range1_str);
+                          exit (EXIT_FAILURE);
+                        }
                     }
                 }
             }
@@ -419,18 +429,22 @@ _read_date_range (int *flag,
     t = time (NULL);
   else
     {
-      if (!strptime (range2_str, "%m/%d/%Y", &tm))
+      if (!strptime (range2_str, "%FT%T", &tm))
         {
-          if (!strptime (range2_str, "%b/%d/%Y", &tm))
+          range2_is_iso8601 = 0;
+          if (!strptime (range2_str, "%m/%d/%Y", &tm))
             {
-              if (!strptime (range2_str, "%m-%d-%Y", &tm))
+              if (!strptime (range2_str, "%b/%d/%Y", &tm))
                 {
-                  if (!strptime (range2_str, "%b-%d-%Y", &tm))
+                  if (!strptime (range2_str, "%m-%d-%Y", &tm))
                     {
-                      fprintf (stderr,
-                               "Invalid time specification '%s'.\n",
-                               range2_str);
-                      exit (EXIT_FAILURE);
+                      if (!strptime (range2_str, "%b-%d-%Y", &tm))
+                        {
+                          fprintf (stderr,
+                                   "Invalid time specification '%s'.\n",
+                                   range2_str);
+                          exit (EXIT_FAILURE);
+                        }
                     }
                 }
             }
@@ -460,8 +474,10 @@ _read_date_range (int *flag,
 
   /* Date range input means beginning of range1 date to end of range2 date
    * so we might need to add seconds to the end of the range2 date.
+   * Only exceptions to this are when range2 is accurate to the second.
+   * Which happens when either range2 is "now" or given in ISO 8601 format.
    */
-  if (strcasecmp (range2_str, "now"))
+  if (strcasecmp (range2_str, "now") && !range2_is_iso8601)
     (*range2) = (*range2) + (24 * 60 * 60);
 
   free (range1_str);

--- a/man/ipmi-sel.8.pre.in
+++ b/man/ipmi-sel.8.pre.in
@@ -75,7 +75,8 @@ Exclude display of SEL records from record id START to END.
 .TP
 \fB\-\-date\-range\fR=\fIDATE\-DATE\fR
 Display SEL records with events occurring in the specified date range.
-Dates may be specified in MM/DD/YYYY or MM-DD-YYYY format.  The month
+Dates may be specified in MM/DD/YYYY, MM-DD-YYYY or the ISO 8601
+YYYY-MM-DDTHH:MM:SS format. For the non ISO 8601 formats, the month
 may be specified as a numeral or its abbreviated string name.  The
 current local system time can be specified with "now".  Note that
 non-timestamped records will not be displayed automatically because
@@ -83,11 +84,12 @@ they do not possess a timestamp.
 .TP
 \fB\-\-exclude\-date\-range\fR=\fIDATE\-DATE\fR
 Exclude display of SEL records with events occurring in the specified
-date range.  Dates may be specified in MM/DD/YYYY or MM-DD-YYYY
-format.  The month may be specified as a numeral or its abbreviated
-string name.  The current local system time can be specified with
-"now".  Note that non-timestamped records will be displayed
-automatically because they do not possess a timestamp.
+date range.  Dates may be specified in MM/DD/YYYY, MM-DD-YYYY or the
+ISO 8601 YYYY-MM-DDTHH:MM:SS format.  For the non ISO 8601 formats,
+the month may be specified as a numeral or its abbreviated string
+name.  The current local system time can be specified with "now".
+Note that non-timestamped records will be displayed automatically
+because they do not possess a timestamp.
 .TP
 \fB\-t\fR \fISENSOR\-TYPE\-LIST\fR, \fB\-\-sensor\-types\fR=\fISENSOR\-TYPE\-LIST\fR
 Specify sensor types to show SEL events for.  Multiple types can be


### PR DESCRIPTION
According to Timestamp section of the IPMI specification[0], the SEL entries have a timestamp resolution of one second. Therefore it is possible to make the command line argument "--date-range" of ipmi-sel more granular.

This patch is adding the usage of (almost)ISO 8601[1] style datetime strings in the "--date-range" argument. The timezone info part of the standard is not implemented since IPMI does not have proper support for it and always assumes the users localtime.

So the option now also accepts datetime format strings in the form

  %Y-%m-%dT%H:%M:%S

e.g. in order to represent the datetime October 14th 2022, 09:05 AM, one would write:

  2022-10-14T09:05:00

A new example usage of the "--date-range" leveraging this would be

  $ ipmi-sel --date-range=2022-10-14T09:05:00-2022-10-15T19:05:00

in order to show SEL records between Oct 14th 09:05 and Oct 15th 19:05 of the year 2022.

[0]
https://www.intel.com/content/www/us/en/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html [1] https://www.iso.org/obp/ui/#iso:std:iso:8601:-1:ed-1:v1:en

Closes: #57
Signed-off-by: Mert Kırpıcı <mert.kirpici@canonical.com>