### PR TITLE
add codespell config file

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,19 @@
+[codespell]
+# Folders and files to skip
+skip = .codespellrc,.git,enterprise-numbers.txt,ipmi-iana-enterprise-numbers-spec.c,jedec-raw.txt,ipmi-jedec-manufacturer-identification-code-spec.c
+# Print N lines of surrounding context
+#context = 1
+# Check hidden files also (empty means True)
+check-hidden=
+# Print number of errors as last line on stderr (empty means True)
+count=
+
+# Dictionaries to use (default: "clear,rare"). Current: all.
+#builtin = clear,rare,informal,usage,code,names,en-GB_to_en-US
+
+# Allowed (ignored) words
+ignore-words-list=usera
+# Allowed (ignored) words in URLs and URIs
+#uri-ignore-words-list=mitre
+
+# Important note: ignored words must be lowercase


### PR DESCRIPTION
Add basic codespell config file with some exclusion, like some spec files that produce many results that can't be fixed is possible other words should be added to exclusion, like compatability (in NEWS and changelog seems are used to document some changes)

this should help people that want to try to fix spelling errors