### PR TITLE
Mention OpenIPMI in the opensesspriv workaround doc

### DIFF
--- a/man/manpage-common-workaround-outofband-20-text.man
+++ b/man/manpage-common-workaround-outofband-20-text.man
@@ -26,12 +26,13 @@ hashing algorithm used by the remote system.  The privilege level sent
 during the Open Session stage of an IPMI 2.0 connection is used for
 hashing keys instead of the privilege level sent during the RAKP1
 connection stage.  Those hitting this issue may see "password
-invalid", "k_g invalid", or "bad rmcpplus status code" errors.  Issue
-observed on Sun Fire 4100/4200/4500 with ILOM, Inventec 5441/Dell
-Xanadu II, Supermicro X8DTH, Supermicro X8DTG, Intel S5500WBV/Penguin
-Relion 700, Intel S2600JF/Appro 512X, Quanta QSSC-S4R/Appro GB812X-CN,
-and Dell C5220.  This workaround is automatically triggered with the
-"sun20" workaround.
+invalid", "k_g invalid", "bad rmcpplus status code", or "privilege
+level cannot be obtained for this user" errors.  Issue observed on Sun
+Fire 4100/4200/4500 with ILOM, Inventec 5441/Dell Xanadu II,
+Supermicro X8DTH, Supermicro X8DTG, Intel S5500WBV/Penguin Relion 700,
+Intel S2600JF/Appro 512X, Quanta QSSC-S4R/Appro GB812X-CN, Dell
+C5220, and the OpenIPMI software BMC.  This workaround is
+automatically triggered with the "sun20" workaround.
 .LP
 \fIintegritycheckvalue\fR - This workaround flag will work around an
 invalid integrity check value during an IPMI 2.0 session establishment


### PR DESCRIPTION
The "opensesspriv" workaround is needed also for the OpenIPMI LAN BMC code (the ipmi_sim IPMI LAN BMC simulator and probably also the ipmilan IPMI LAN to system interface converter, although I have not tested the latter). The error message when the workaround is not used is different from the other documented cases though: "privilege level cannot be obtained for this user". Document this in the man pages.